### PR TITLE
Use repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hangarjs",
   "description": "Use hangar factories from protractor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "maintainers": [
     {
       "name": "Faraday",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,10 @@
       "web": "http://faraday.io"
     }
   ],
-  "repositories": [
-    {
-      "type": "git",
-      "url": "git@github.com:faradayio/hangarjs.git"
-    }
-  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:faradayio/hangarjs.git"
+  },
   "dependencies": {
     "inflection": "~1.3.5"
   }


### PR DESCRIPTION
Fixes npm warning: 'repositories' (plural) Not supported. Please pick one as the 'repository' field
